### PR TITLE
Setup dot net docker

### DIFF
--- a/KeyCloakIntegration/DockerFile
+++ b/KeyCloakIntegration/DockerFile
@@ -1,0 +1,17 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+WORKDIR /KeyCloakIntegration
+RUN apt-get update -yq 
+RUN apt-get install curl gnupg -yq 
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - 
+RUN apt-get install -y nodejs
+# Copy everything
+COPY . ./
+# Restore as distinct layers
+RUN dotnet restore
+# Build and publish a release
+RUN dotnet publish ./src/Web/ -c Release -o out
+
+# Build runtime image
+FROM mcr.microsoft.com/dotnet/aspnet:8.0
+COPY --from=build-env /KeyCloakIntegration/out .
+ENTRYPOINT ["dotnet", "KeyCloakIntegration.Web.dll"]

--- a/README.md
+++ b/README.md
@@ -6,3 +6,8 @@
 `docker pull keycloak/keycloak`
 1. Start Keycloak with the following command `docker run -p 8080:8080 -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin quay.io/keycloak/keycloak:26.0.0 start-dev` This command starts Keycloak exposed on the local port 8080 and creates an initial admin user with the `username admin` and `password admin`.
 1. Log in into [Keycloak](http://localhost:8080/admin)
+
+# DotNet Setup
+1. From [DockerFile directory](/KeyCloakIntegration/) run: `docker build -t dotnet_keycloak-image -f DockerFile .`
+1. Start app with the following command `docker run -d -p 8081:8080 dotnet_keycloak-image`
+1. Navigate to [app]((http://localhost:8081/)


### PR DESCRIPTION
A DockerFile has been added with instructions to setup a dotnet machine with node support to build and publish the application to a different port than Keycloak